### PR TITLE
fix(github.go): supply access token via authz header per GH api

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -145,11 +145,9 @@ func (c Client) getPaginated(uri string) (io.ReadCloser, error) {
 
 	v := u.Query()
 	v.Set("per_page", "100") // The default is 30, this makes it less likely for Github to rate-limit us.
-	if c.Token != "" {
-		v.Set("access_token", c.Token)
-	}
 	u.RawQuery = v.Encode()
-	resp, err := http.Get(u.String())
+
+	resp, err := DoAuthRequest(http.MethodGet, u.String(), "", c.Token, nil, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates api usage to supply the access token in the form of an Authorization header as opposed to a query parameter, as informed by GitHub:

```
On February 12th, 2020 at 16:28 (UTC) your personal access token (general curl token) using Go-http-client/1.1 was used as part of a query parameter to access an endpoint through the GitHub API:

Please use the Authorization HTTP header instead, as using the `access_token` query parameter is deprecated and will be removed July 1st, 2020.
```

Tested via building the cli (`make`) and issuing an `info` command, e.g. `./github-release info -u brigadecore -r brigade`.  (Command works and no email response from GH received.)